### PR TITLE
ci(frontend): add OWNERS file to enable Prow approve workflow

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- smrtrfszm
+- TwoDCube


### PR DESCRIPTION
## Summary

Adds a root `OWNERS` file so Prow's `approve` plugin has a list of approvers.

## Why

Tide is configured to require both the `lgtm` **and** `approved` labels before merging (see `website_k8s/verseghy-website/prow/configmaps.yaml`). The `approved` label is only granted when an approver listed in an `OWNERS` file runs `/approve`. This repo has no `OWNERS` file, so no one can grant `approved` and PRs (e.g. #1164) stay permanently `BLOCKED` even with `lgtm`.

Approvers copied from `website_backend2`:
- smrtrfszm
- TwoDCube

## Note

This bootstrap PR may itself be blocked by the same mechanism (base branch has no OWNERS yet), so it likely needs an admin merge / direct push to `master`. Once it lands, #1164 and other open PRs can be unblocked with `/approve`.